### PR TITLE
Generate modlist to README from mod manifest

### DIFF
--- a/.github/workflows/markdown-gen.yml
+++ b/.github/workflows/markdown-gen.yml
@@ -1,0 +1,33 @@
+name: Generate mods list markdown
+
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  Generate-Markdown:
+    runs-on: ubuntu-latest
+    steps:
+      - name: checkout
+        uses: actions/checkout@v2
+    
+      - name: setup python
+        uses: actions/setup-python@v3
+        with:
+          python-version: "3"
+
+      - name: generate readme
+        run: ./gen_readme.py
+
+      - name: setup git config
+        run: |
+          git config user.name "GitHub Actions"
+          git config user.email "<>"
+
+      - name: commit
+        continue-on-error: true
+        run: |
+          git add --force README.md
+          git commit -m "Update mods list"
+          git push origin master

--- a/README-template.md
+++ b/README-template.md
@@ -1,0 +1,11 @@
+# Neos Mod Manifest
+
+Work in progress!
+
+This is a machine-readable listing of known Neos mods.
+
+The [schema documentation](docs/schema.md) explains what the fields [the manifest](manifest.json) mean.
+
+The below list is automatically generated from the manifest with github actions.
+
+## Mods

--- a/README.md
+++ b/README.md
@@ -5,3 +5,499 @@ Work in progress!
 This is a machine-readable listing of known Neos mods.
 
 The [schema documentation](docs/schema.md) explains what the fields [the manifest](manifest.json) mean.
+
+The below list is automatically generated from the manifest with github actions.
+
+## Mods
+
+### Asset Importing Tweaks
+
+<!--net.dfghiatus.autoimageresize-->
+#### [AutoResizeImages](https://github.com/dfgHiatus/AutoResizeImages) by [dfgHiatus](https://github.com/dfgHiatus)
+
+Automatically resize large square, power-of-2 textures
+
+<!--me.art0007i.customvideoplayers-->
+#### [CustomVideoPlayers](https://github.com/art0007i/CustomVideoPlayers) by [art0007i](https://github.com/art0007i)
+
+Lets you change your default video player
+
+<!--tk.kawaiiamber.gifimporter-->
+#### [GifImporter](https://github.com/kawaiiamber/GifImporter) by [amber](https://github.com/kawaiiamber)
+
+Allows you to import gif images
+
+<!--me.art0007i.gifimporter-->
+#### [GifImporter (arti's fork)](https://github.com/art0007i/GifImporter) by [art0007i](https://github.com/art0007i)
+
+GifImporter but it tries to fit the sprite sheets into a square resolution, it will sometimes create redundant empty frames at the end of the gif
+
+<!--dev.kokoa.neospastetweak-->
+#### [NeosPasteTweak](https://github.com/rassi0429/NeosPasteTweak) by [kka429](https://github.com/rassi0429)
+
+Allows you to paste text and URL
+
+<!--me.art0007i.pasteinvidious-->
+#### [PasteInvidious](https://github.com/art0007i/PasteInvidious) by [art0007i](https://github.com/art0007i)
+
+Changes all pasted youtube links to invidious links
+
+### Bug Workarounds
+
+<!--io.github.kyuubiyoru.disablelibvlc-->
+#### [DisableLibVLC](https://github.com/KyuubiYoru/DisableLibVLC) by [KyuubiYoru](https://github.com/KyuubiYoru)
+
+Disable libVLC to prevent crashes in Windows
+
+<!--me.art0007i.fixuixbutton-->
+#### [FixUIXButton](https://github.com/art0007i/FixUIXButton) by [art0007i](https://github.com/art0007i)
+
+Adds a button to RectTransforms that fixes broken uix
+
+<!--xyz.ljoonal.neos.linuxfixes-->
+#### [LinuxFixes](https://neos.ljoonal.xyz/mods/#linux-fixes) by [ljoonal](https://www.ljoonal.xyz/)
+
+Linux fixes for item rotation not working properly, centers mouse on context menu open and un-reverses the scroll wheel direction
+
+<!--io.github.frozenreflex.neosvideoplayerfix-->
+#### [NeosVideoPlayerFix](https://github.com/Frozenreflex/NeosVideoPlayerFix) by [Fro Zen](https://github.com/Frozenreflex)
+
+Force libVLC to prevent crashes in Proton
+
+<!--net.dfghiatus.mixnmatch_lipsnmouth-->
+#### [mixNmatch_lipsNmouth](https://github.com/dfgHiatus/mixNmatch_lipsNmouth) by [dfgHiatus](https://github.com/dfgHiatus)
+
+Allows for differing makes and models of Eye and Face Trackers to operate together
+
+### Context Menu Tweaks
+
+<!--dev.zkxs.neoslocomotionrename-->
+#### [NeosLocomotionRename](https://github.com/zkxs/NeosLocomotionRename) by [runtime](https://github.com/zkxs)
+
+Lets you rename your locomotion modules
+
+<!--dev.zkxs.neosnoresetscale-->
+#### [NeosNoResetScale](https://github.com/zkxs/NeosNoResetScale) by [runtime](https://github.com/zkxs)
+
+Removes the "Reset Scale" context menu function
+
+<!--dev.kokoa.savetowhere-->
+#### [SaveToWhere](https://github.com/rassi0429/SaveToWhere) by [kka429](https://github.com/rassi0429)
+
+Displays the save destination for the save to inventory button
+
+### Dash Tweaks
+
+<!--net.rampa3.3ddashonscreen-->
+#### [3DDashOnScreen](https://github.com/rampa3/3DDashOnScreen) by [rampa3](https://github.com/rampa3)
+
+replaces 2D overlay dash in Screen mode with the regular 3D one
+
+<!--net.eia485.allowmultipleaudiostreams-->
+#### [AllowMultipleAudioStreams](https://github.com/EIA485/NeosAllowMultipleAudioStreams) by [eia485](https://github.com/EIA485)
+
+Allows you to spawn multiple audio streams
+
+<!--me.badhaloninja.contactspublishedworldsbutton-->
+#### [ContactsPublishedWorldsButton](https://github.com/badhaloninja/ContactsPublishedWorldsButton) by [badhaloninja](https://github.com/badhaloninja)
+
+Adds a button to contacts to show their published worlds
+
+<!--net.eia485.getitemlink-->
+#### [GetItemLink](https://github.com/EIA485/NeosGetItemLink) by [eia485](https://github.com/EIA485)
+
+Adds buttons to your inventory to copy an items cloud url and/or item link to your clipboard
+
+<!--net.cyro.loadalready-->
+#### [LoadAlready](https://github.com/RileyGuy/LoadAlready) by [Cyro](https://github.com/RileyGuy)
+
+Lets you double-click the loading indicator to remove it if the loading bug occurs
+
+<!--dev.kokoa.messagecopy-->
+#### [MessageCopy](https://github.com/rassi0429/MessageCopy) by [kka429](https://github.com/rassi0429)
+
+Lets you copy msgs from dms
+
+<!--me.badhaloninja.neosmodsettings-->
+#### [ModSettings](https://github.com/badhaloninja/NeosModSettings) by [badhaloninja](https://github.com/badhaloninja)
+
+Adds a dash screen to edit mod configs
+
+<!--dev.zkxs.neoscontactssort-->
+#### [NeosContactsSort](https://github.com/zkxs/NeosContactsSort) by [runtime](https://github.com/zkxs)
+
+Sorts contacts Better™
+
+<!--net.kazu0617.sessiontweaks-->
+#### [SessionTweaks](https://github.com/kazu0617/SessionTweaks) by [kazu0617](https://github.com/kazu0617)
+
+Adds buttons for session orb / copy session uri to your contact's tab
+
+<!--net.dfghiatus.speedyurls-->
+#### [SpeedyURLs](https://github.com/dfgHiatus/SpeedyURLs) by [dfgHiatus](https://github.com/dfgHiatus)
+
+Removes the 5-second cool-down on hyperlinks
+
+### For Mod Developers
+
+<!--net.Toxic_Cookie.GenericSettings-->
+#### [GenericSettings](https://github.com/Toxic-Cookie/GenericSettings) by [Toxic_Cookie](https://github.com/Toxic-Cookie)
+
+Allows you to define, save, load and use custom settings
+
+### General Ui Tweaks
+
+<!--net.eia485.reduceanimation-->
+#### [ReduceAnimation](https://github.com/EIA485/NeosReduceAnimation) by [eia485](https://github.com/EIA485)
+
+Reduce ui animations
+
+<!--net.cyro.squishspector-->
+#### [SquishPanels](https://github.com/RileyGuy/SquishPanels) by [Cyro](https://github.com/RileyGuy)
+
+Modify the NeosPanels in Neos to squish in and out of existence
+
+### Hardware Integrations
+
+<!--net.dfghiatus.neos-wcface-integration-->
+#### [Neos-WCFace-Integration](https://github.com/dfgHiatus/Neos-WCFace-Integration) by [dfgHiatus](https://github.com/dfgHiatus)
+
+Integrates WCFace's screen-mode eye tracking
+
+<!--net.dfg.pimaxeyetracking-->
+#### [PimaxEyeTracker](https://github.com/dfgHiatus/NeosPimaxEyeTracker) by [dfgHiatus](https://github.com/dfgHiatus)
+
+Integrates the Droolon Pi1 eye tracking module
+
+<!--net.dfghiatus.neosvarjoeyetracking-->
+#### [VarjoEyeTracking](https://github.com/dfgHiatus/NeosVarjoEyeTracking) by [dfgHiatus](https://github.com/dfgHiatus)
+
+Integrates the Varjo Areo's Eye tracking into NeosVR
+
+### Inspectors
+
+<!--me.art0007i.colordrop-->
+#### [ColorDrop](https://github.com/art0007i/ColorDrop) by [art0007i](https://github.com/art0007i)
+
+Makes it so you can grab and drop colors
+
+<!--net.Toxic_Cookie.fieldexpressions-->
+#### [FieldExpressions](https://github.com/Toxic-Cookie/FieldExpressions) by [Toxic_Cookie](https://github.com/Toxic-Cookie)
+
+ Allows you to use CodingSeb's Expression Evaluator in inspector fields
+
+<!--net.eia485.localslotnames-->
+#### [LocalSlotNames](https://github.com/EIA485/NeosLocalSlotNames) by [eia485](https://github.com/EIA485)
+
+Shows the local name of a slot in the hierarchy
+
+<!--net.eia485.morereferenceproxies-->
+#### [MoreReferenceProxies](https://github.com/EIA485/NeosMoreReferenceProxies) by [eia485](https://github.com/EIA485)
+
+Adds reference proxy sources to bag editors and list editors
+
+<!--tk.deltawolf.NeosNonPersistentInspectors-->
+#### [NonPersistentInspectors](https://github.com/XDelta/NeosNonPersistentInspectors) by [Delta](https://github.com/XDelta)
+
+Makes spawned inspectors set to nonpersistent by default
+
+<!--me.art0007i.showcomponentslot-->
+#### [ShowComponentSlot](https://github.com/art0007i/ShowComponentSlot) by [art0007i](https://github.com/art0007i)
+
+Allows you to open the slot that a component is attached to in component inspectors
+
+<!--me.art0007i.showdelegates-->
+#### [ShowDelegates](https://github.com/art0007i/ShowDelegates) by [art0007i](https://github.com/art0007i)
+
+Shows delegates in inspectors
+
+<!--me.art0007i.showdrivesource-->
+#### [ShowDriveSource](https://github.com/art0007i/ShowDriveSource) by [art0007i](https://github.com/art0007i)
+
+Allows viewing what a field is driven by
+
+### Keybinds & Gestures
+
+<!--dev.zkxs.neosdesktoptoolshortcutremapper-->
+#### [DesktopToolShortcutRemapper](https://github.com/zkxs/NeosDesktopToolShortcutRemapper) by [runtime](https://github.com/zkxs)
+
+Remaps `5` on desktop from ShapeTip to ComponentCloneTip
+
+<!--net.kazu0617.desktoptoolshortcutremapper-->
+#### [DesktopToolShortcutRemapper (kazu's fork)](https://github.com/kazu0617/DesktopToolShortcutRemapper) by [kazu0617](https://github.com/kazu0617)
+
+Fully configurable number key bindings for spawning arbitrary tools
+
+<!--net.dfghiatus.fingerqrcode-->
+#### [FingerQRCode](https://github.com/dfgHiatus/FingerQRCode) by [dfgHiatus](https://github.com/dfgHiatus)
+
+Adds URL-QR Code reader functionality to the finger photo gesture
+
+<!--me.art0007i.inspectorscroll-->
+#### [InspectorScroll](https://github.com/art0007i/InspectorScroll) by [art0007i](https://github.com/art0007i)
+
+Allows you to scroll UIX panels (including inspectors) using the thumbstick / touchpad
+
+<!--net.eia485.killdesktoptools-->
+#### [KillDesktopTools](https://github.com/EIA485/NeosKillDesktopTools) by [eia485](https://github.com/EIA485)
+
+Disables the desktop tool keybinds
+
+<!--dev.zkxs.noescape-->
+#### [NoEscape](https://github.com/zkxs/NoEscape) by [runtime](https://github.com/zkxs)
+
+Removes the emergency respawn gesture
+
+<!--me.art0007i.noheadmenudash-->
+#### [NoHeadMenuDash](https://github.com/art0007i/NoHeadMenuDash) by [art0007i](https://github.com/art0007i)
+
+Removes the gesture that opens the dash when you press the menu button near your head
+
+<!--net.eia485.noleftjump-->
+#### [NoLeftJump](https://github.com/EIA485/NeosNoLeftJump) by [eia485](https://github.com/EIA485)
+
+Disables your left thumbstick being used as a jump
+
+<!--U-xyla.xymod-->
+#### [NoTankControls](https://github.com/furrz/NoTankControls) by [xyla](https://github.com/furrz)
+
+Allows you to move with your joysticks while holding any tool
+
+<!--me.badhaloninja.nouserspaceundo-->
+#### [NoUserspaceUndo](https://github.com/badhaloninja/NoUserspaceUndo) by [badhaloninja](https://github.com/badhaloninja)
+
+Disables the UndoManager in userspace
+
+<!--tk.deltawolf.NeosPTTKeybinds-->
+#### [PTTKeybinds](https://github.com/XDelta/NeosPTTKeybinds) by [Delta](https://github.com/XDelta)
+
+Disable Push-to-Talk keybinds like mouse5, V, or M. Includes config to adjust which are disabled
+
+<!--me.badhaloninja.primaryhandlegacyworldswitcher-->
+#### [PrimaryHandLegacyWorldSwitcher](https://github.com/badhaloninja/PrimaryHandLegacyWorldSwitcher) by [badhaloninja](https://github.com/badhaloninja)
+
+Changes the legacy world switcher to open depending on the primary hand setting
+
+### Logix
+
+<!--net.cyro.darklogixbrowser-->
+#### [DarkLogiXBrowser](https://github.com/RileyGuy/DarkLogiXBrowser) by [Cyro](https://github.com/RileyGuy)
+
+Make the logix node browser darkmode and single-click
+
+<!--net.kazu0617.disablecustomconnectpoint-->
+#### [DisableCustomConnectPoint](https://github.com/kazu0617/DisableCustomConnectPoint) by [kazu0617](https://github.com/kazu0617)
+
+disables custom input/output attributes for LogiX nodes
+
+<!--net.eia485.exposeallimpulses-->
+#### [ExposeAllImpulses](https://github.com/EIA485/NeosExposeAllImpulses) by [eia485](https://github.com/EIA485)
+
+Exposes all valid logix impulse targets
+
+<!--net.eia485.exposeallsyncmembers-->
+#### [ExposeAllSyncMembers](https://github.com/EIA485/NeosExposeAllSyncMembers) by [eia485](https://github.com/EIA485)
+
+Exposes all SyncMembers on interfaces
+
+<!--net.eia485.fixtostring-->
+#### [FixToString](https://github.com/EIA485/NeosFixToString) by [eia485](https://github.com/EIA485)
+
+Fixes the to string logix node
+
+<!--me.badhaloninja.logixutils-->
+#### [LogixUtils](https://github.com/badhaloninja/LogixUtils) by [badhaloninja](https://github.com/badhaloninja)
+
+Tweaks some logix things
+
+<!--net.eia485.ReferenceNodeHotline-->
+#### [ReferenceNodeHotline](https://github.com/EIA485/NeosReferenceNodeHotline) by [eia485](https://github.com/EIA485)
+
+Stops reference nodes from killing themselves
+
+### Memes
+
+<!--net.eia485.cheese4all-->
+#### [Cheese4All](https://github.com/EIA485/NeosCheese4All) by [eia485](https://github.com/EIA485)
+
+Enables the top secret cheese mode
+
+<!--net.eia485.dezomp4all-->
+#### [DeZomp4All](https://github.com/EIA485/NeosDeZomp4All) by [eia485](https://github.com/EIA485)
+
+Shows the hidden DeZomp
+
+<!--net.eia485.fools-->
+#### [Fools](https://github.com/EIA485/NeosFools) by [eia485](https://github.com/EIA485)
+
+Forces April Fools mode
+
+<!--me.badhaloninja.printimportreport-->
+#### [PrintImportReport](https://github.com/badhaloninja/PrintImportReport) by [badhaloninja](https://github.com/badhaloninja)
+
+Makes Import Report spawn in the real world instead
+
+<!--net.eia485.showhiddennodes-->
+#### [ShowHiddenNodes](https://github.com/EIA485/NeosShowHiddenNodes) by [eia485](https://github.com/EIA485)
+
+Shows hidden nodes in the node browser
+
+<!--me.art0007i.toolshelfanarchy-->
+#### [ToolshelfAnarchy](https://github.com/art0007i/ToolshelfAnarchy) by [art0007i](https://github.com/art0007i)
+
+Allows you to take and put tools on other peoples toolshelves
+
+<!--net.eia485.youwantdarkmode-->
+#### [YouWantDarkmode?](https://github.com/EIA485/NeosYouWantDarkmode) by [eia485](https://github.com/EIA485)
+
+Makes EVERYTHING dark mode
+
+### Misc
+
+<!--net.eia485.desktopphisicalgrab-->
+#### [DesktopPhisicalGrab](https://github.com/EIA485/NeosDesktopPhisicalGrab) by [eia485](https://github.com/EIA485)
+
+Enables physical grabbing in screen mode
+
+<!--net.eia485.exposepatchedmethods-->
+#### [ExposePatchedMethods](https://github.com/EIA485/NeosExposePatchedMethods) by [eia485](https://github.com/EIA485)
+
+Exposes what mods you have loaded to your userspace
+
+<!--xyz.ljoonal.neos.latestlog-->
+#### [LatestLog](https://neos.ljoonal.xyz/mods/#latest-log) by [ljoonal](https://www.ljoonal.xyz/)
+
+Creates a symbolic link in the Neos folder named Latest.log to the latest log file that was created on launch
+
+<!--net.sox.localstreamvolume-->
+#### [LocalStreamVolume](https://github.com/Sox-NeosVR/LocalStreamVolume) by [Sox](https://github.com/Sox-NeosVR)
+
+ Makes any audio stream you create have a local volume slider
+
+<!--net.sox.localvideoplayervolume-->
+#### [LocalVideoPlayerVolume](https://github.com/Sox-NeosVR/LocalVideoPlayerVolume) by [Sox](https://github.com/Sox-NeosVR)
+
+Automatically makes any video you import have a local volume slider
+
+<!--dev.zkxs.neosplatformspoof-->
+#### [NeosPlatformSpoof](https://github.com/zkxs/NeosPlatformSpoof) by [runtime](https://github.com/zkxs)
+
+Lets you change your displayed platform and show some Linux pride even on Proton
+
+<!--dev.zkxs.neostrackeridstabilizer-->
+#### [NeosTrackerIdStabilizer](https://github.com/zkxs/NeosTrackerIdStabilizer) by [runtime](https://github.com/zkxs)
+
+Restores Vive tracker names to their old LHR-whatever behavior
+
+<!--net.eia485.nosteam-->
+#### [NoSteam](https://github.com/EIA485/NeosNoSteam) by [eia485](https://github.com/EIA485)
+
+Partially stops neos from connecting to steam
+
+<!--xyz.ljoonal.neos.privacyshield-->
+#### [PrivacyShield](https://neos.ljoonal.xyz/mods/#privacy-shield) by [ljoonal](https://www.ljoonal.xyz/)
+
+Some privacy enhancements like requesting web permission for anything outside of Neos APIs, not just web requests. Also timezone and FPS spoofing.
+
+<!--dev.zkxs.voicevolumeoverride-->
+#### [VoiceVolumeOverride](https://github.com/zkxs/VoiceVolumeOverride) by [runtime](https://github.com/zkxs)
+
+Lets you adjust your microphone volume in-game
+
+### Optimization
+
+<!--net.eia485.betterlogixwires-->
+#### [BetterLogixWires](https://github.com/EIA485/NeosBetterLogixWires) by [eia485](https://github.com/EIA485)
+
+Optimizes the rendering of logix wires
+
+<!--net.dfghiatus.cachegetclapped-->
+#### [CacheGetClapped](https://github.com/dfgHiatus/CacheGetClapped) by [dfgHiatus](https://github.com/dfgHiatus)
+
+Deletes cached files that have been unused for over 21 days
+
+<!--io.github.kyuubiyoru.ikculling-->
+#### [IkCulling](https://github.com/KyuubiYoru/IkCulling) by [KyuubiYoru](https://github.com/KyuubiYoru)
+
+Disables the IK of Users who are behind you or far away
+
+<!--net.eia485.killlogspam-->
+#### [KillLogSpam](https://github.com/EIA485/NeosKillLogSpam) by [eia485](https://github.com/EIA485)
+
+Kills the log spam normally caused by changing world configuration
+
+### Technical Tweaks
+
+<!--net.eia485.allshadersvalid-->
+#### [AllShadersValid](https://github.com/EIA485/NeosAllShadersValid) by [eia485](https://github.com/EIA485)
+
+Lets you use non neos sanctioned shaders
+
+<!--net.eia485.anyshaderanywhere-->
+#### [AnyShaderAnywhere](https://github.com/EIA485/NeosAnyShaderAnywhere) by [eia485](https://github.com/EIA485)
+
+Lets you use any StaticShader in any Material
+
+<!--dev.zkxs.exportneostojson-->
+#### [ExportNeosToJson](https://github.com/zkxs/ExportNeosToJson) by [runtime](https://github.com/zkxs)
+
+Lets you export Neos objects as their native format
+
+<!--net.eia485.extendcompatibility-->
+#### [ExtendCompatibility](https://github.com/EIA485/NeosExtendCompatibility) by [eia485](https://github.com/EIA485)
+
+Prevents crashing from invalid SyncMembers
+
+<!--me.badhaloninja.generictypeadditions-->
+#### [GenericTypeAdditions](https://github.com/badhaloninja/GenericTypeAdditions) by [badhaloninja](https://github.com/badhaloninja)
+
+Adds more types to the GenericTypes lists
+
+<!--net.cyro.inspectrum-->
+#### [Inspectrum](https://github.com/RileyGuy/Inspectrum) by [Cyro](https://github.com/RileyGuy)
+
+Makes the color of your inspector panels reflect your custom user color cloud variable
+
+<!--net.eia485.showhiddencategory-->
+#### [ShowHiddenCategory](https://github.com/EIA485/NeosShowHiddenCategory) by [eia485](https://github.com/EIA485)
+
+Shows the hidden category
+
+### Visual Tweaks
+
+<!--dev.zkxs.motionblurdisable-->
+#### [MotionBlurDisable](https://github.com/zkxs/MotionBlurDisable) by [runtime](https://github.com/zkxs)
+
+Disables motion blur for all of your cameras, including your view
+
+<!--me.badhaloninja.optizoom-->
+#### [Optizoom](https://github.com/badhaloninja/Optizoom) by [badhaloninja](https://github.com/badhaloninja)
+
+Adds the ability to zoom with a keypress
+
+<!--net.cyro.photonicfreedom-->
+#### [PhotonicFreedom](https://github.com/RileyGuy/PhotonicFreedom) by [Cyro](https://github.com/RileyGuy)
+
+Adds settings for Ambient Occlusion and Motion Blur
+
+<!--xyz.ljoonal.neos.screenmodetweaks-->
+#### [ScreenmodeTweaks](https://neos.ljoonal.xyz/mods/#screenmode-tweaks) by [ljoonal](https://www.ljoonal.xyz/)
+
+Forces vsync to be disabled
+
+<!--dev.zkxs.ssaodisable-->
+#### [SsaoDisable](https://github.com/zkxs/SsaoDisable) by [runtime](https://github.com/zkxs)
+
+Disables SSAO for all of your cameras, including your view
+
+### Wizards
+
+<!--net.dfghiatus.dynamicbonechainwizardmod-->
+#### [DynamicBoneChainWizardMod](https://github.com/dfgHiatus/DynamicBoneChainWizardMod) by [dfgHiatus](https://github.com/dfgHiatus)
+
+Automatically sets up Dynamic Bone Chains on avatars and validly named slots
+
+<!--net.toxic_cookie.neosbakery-->
+#### [NeosBakery](https://github.com/Toxic-Cookie/NeosBakery) by [Toxic_Cookie](https://github.com/Toxic-Cookie)
+
+A light baking solution for NeosVR

--- a/gen_readme.py
+++ b/gen_readme.py
@@ -1,0 +1,44 @@
+#!/bin/python
+import json
+
+grouped_mods = {}
+
+with open("manifest.json", "r", encoding = "UTF-8") as f:
+    MANIFEST = json.load(f)
+    for mod_guid in MANIFEST["mods"]:
+        mod = MANIFEST["mods"][mod_guid]
+        mod["guid"] = mod_guid
+
+        if "flags" not in mod or (
+            "plugin" not in mod["flags"] and
+            "file" not in mod["flags"]
+        ):
+            mods = grouped_mods.get(mod["category"])
+            if mods is None:
+                mods = []
+
+            mods.append(mod)
+            grouped_mods[mod["category"]] = mods
+
+README = None
+with open("README-template.md", "r", encoding = "UTF-8") as f:
+    README = f.read()
+
+for group, mods in grouped_mods.items():
+    mods = mods.sort(key=lambda mod: mod["name"])
+
+for group, mods in sorted(grouped_mods.items()):
+    README += f"\n### {group}\n"
+    for mod in mods:
+        README += "\n<!--" + mod["guid"] + "-->\n"
+        README += "#### "
+        README += f"[{mod['name']}]({mod['sourceLocation']})"
+        README += " by "
+        README += f"[{mod['author']}]({mod['authorUrl']})"
+        README += "\n\n"
+
+        README += mod['description'] + "\n"
+
+
+with open("README.md", "w", encoding = "UTF-8") as f:
+    f.write(README)


### PR DESCRIPTION
Using Github actions we can generate a modlist directly into the README file, making the manifest the one and only source of truth, de-duplicating the current work of having two different mod list documents.