### PR TITLE
Specify timezone explicitly in the last updated at text

### DIFF
--- a/gen_readme.py
+++ b/gen_readme.py
@@ -25,9 +25,9 @@ README = None
 with open("gh-pages/.templates/mod-list-template.md", "r", encoding = "UTF-8") as f:
     README = f.read()
 
-now = datetime.datetime.now()
-README += "Last updated on "
-README += f"<time datetime='{now.isoformat()}'>{now.strftime('%I:%S, %d %B %Y')}</time>\n\n"
+now = datetime.datetime.now(tz=datetime.timezone.utc)
+README += "Last updated at "
+README += f"<time datetime='{now.isoformat()}'>{now.strftime('%d %B %Y, %I:%S')} UTC</time>\n\n"
 
 for group, mods in grouped_mods.items():
     mods = mods.sort(key=lambda mod: mod["name"])


### PR DESCRIPTION
Since the time is not localized, it's currently potentially confusing for people who're used to seeing times that are localized to their timezones with JS.

An alternative to this approach would be to make JS that does localize the time, but as some users might not have JS enabled, I think that just specifying that it's UTC time is good enough.