### PR TITLE
Improve markdown generation

### DIFF
--- a/.github/workflows/markdown-gen.yml
+++ b/.github/workflows/markdown-gen.yml
@@ -25,7 +25,9 @@ jobs:
           python-version: "3"
 
       - name: generate readme
-        run: ./gen_readme.py
+        run: |
+          cp gh-pages/.templates/mod-list-template.md gh-pages/mods.md
+          ./gen_readme.py < manifest.json >> gh-pages/mods.md
 
       - name: commit
         env:

--- a/gen_readme.py
+++ b/gen_readme.py
@@ -47,6 +47,10 @@ def should_show_mod(mod: dict[str, Any]):
     mod: The mod in question
     """
 
+    # Don't add listings for NSFW mods on the website by default.
+    if mod["category"] == "NSFW":
+        return False
+
     # Only show mods with versions
     if mod["versions"] is None or len(mod["versions"]) == 0:
         return False

--- a/gen_readme.py
+++ b/gen_readme.py
@@ -124,7 +124,7 @@ README = ""
 # Add update time to the start of the markdown
 now = datetime.datetime.now(tz=datetime.timezone.utc)
 README += "Last updated at "
-README += f"<time datetime='{now.isoformat()}'>{now.strftime('%d %B %Y, %I:%S')} UTC</time>\n\n"
+README += f"<time datetime='{now.isoformat()}'>{now.strftime('%d %B %Y, %I:%S')} UTC</time>\n"
 
 # Iterate over the groups in an alphabetical fashion.
 for group, mods in sorted(grouped_mods.items()):

--- a/gen_readme.py
+++ b/gen_readme.py
@@ -4,13 +4,13 @@
 Generates a markdown file to stdout from the JSON manifest passed in with stdin
 """
 
-# pylint: disable=redefined-outer-name
+# pylint: disable=redefined-outer-name,broad-except
 
 import json
 import datetime
 import sys
-import packaging.version
 from typing import Any
+import packaging.version
 
 def should_show_mod(mod: dict[str, Any]) -> bool:
     """

--- a/gen_readme.py
+++ b/gen_readme.py
@@ -1,29 +1,35 @@
 #!/bin/python
+
+"""
+Generates a markdown file to stdout from the JSON manifest passed in with stdin
+"""
+
+# pylint: disable=redefined-outer-name
+
 import json
 import datetime
+import sys
+from typing import Any
 
-grouped_mods = {}
+grouped_mods: dict[str, dict] = {}
 
-with open("manifest.json", "r", encoding = "UTF-8") as f:
-    MANIFEST = json.load(f)
-    for mod_guid in MANIFEST["mods"]:
-        mod = MANIFEST["mods"][mod_guid]
-        mod["guid"] = mod_guid
+MANIFEST: dict[str, dict[str, Any]] = json.load(sys.stdin)
+for mod_guid in MANIFEST["mods"]:
+    mod = MANIFEST["mods"][mod_guid]
+    mod["guid"] = mod_guid
 
-        if "flags" not in mod or (
-            "plugin" not in mod["flags"] and
-            "file" not in mod["flags"]
-        ):
-            mods = grouped_mods.get(mod["category"])
-            if mods is None:
-                mods = []
+    if "flags" not in mod or (
+        "plugin" not in mod["flags"] and
+        "file" not in mod["flags"]
+    ):
+        mods = grouped_mods.get(mod["category"])
+        if mods is None:
+            mods = []
 
-            mods.append(mod)
-            grouped_mods[mod["category"]] = mods
+        mods.append(mod)
+        grouped_mods[mod["category"]] = mods
 
-README = None
-with open("gh-pages/.templates/mod-list-template.md", "r", encoding = "UTF-8") as f:
-    README = f.read()
+README = ""
 
 now = datetime.datetime.now(tz=datetime.timezone.utc)
 README += "Last updated at "
@@ -33,7 +39,7 @@ for group, mods in grouped_mods.items():
     mods = mods.sort(key=lambda mod: mod["name"])
 
 
-def should_show_mod(mod):
+def should_show_mod(mod: dict[str, Any]):
     """
     Checks if mod should be shown.
 
@@ -81,6 +87,4 @@ for group, mods in sorted(grouped_mods.items()):
 
         README += mod['description'] + "\n"
 
-
-with open("gh-pages/mods.md", "w", encoding = "UTF-8") as f:
-    f.write(README)
+print(README)

--- a/gen_readme.py
+++ b/gen_readme.py
@@ -10,7 +10,7 @@ import json
 import datetime
 import sys
 from typing import Any
-import packaging.version
+from packaging.version import Version
 
 def should_show_mod(mod: dict[str, Any]) -> bool:
     """
@@ -70,7 +70,7 @@ for mod_guid in MANIFEST["mods"]:
     for version_id in mod["versions"]:
         try:
             mod_version = mod["versions"][version_id]
-            mod_version["id"] = packaging.version.parse(version_id)
+            mod_version["id"] = Version(version_id)
             versions_list.append(mod_version)
         except Exception as e:
             print(
@@ -81,6 +81,9 @@ for mod_guid in MANIFEST["mods"]:
 
     # Transfer only mods that should be shown to grouped_mods
     if should_show_mod(mod):
+        # Sort the mod's versions
+        mod["versions"].sort(key=lambda version: version["id"])
+
         # Get the group for the mods,
         # or create it if it doesn't exist.
         mods_group = grouped_mods.get(mod["category"])
@@ -94,7 +97,7 @@ for mod_guid in MANIFEST["mods"]:
 
 # Sort the groups' mods
 for group, mods in grouped_mods.items():
-    mods = mods.sort(key=lambda mod: mod["name"])
+    mods.sort(key=lambda mod: mod["name"])
 
 # The markdown output
 README = ""

--- a/gen_readme.py
+++ b/gen_readme.py
@@ -101,7 +101,7 @@ for mod_guid in MANIFEST["mods"]:
     # Transfer only mods that should be shown to grouped_mods
     if should_show_mod(mod):
         # Sort the mod's versions
-        mod["versions"].sort(key=lambda version: version["id"])
+        mod["versions"].sort(reverse=True, key=lambda version: version["id"])
 
         # Get the group for the mods,
         # or create it if it doesn't exist.

--- a/gen_readme.py
+++ b/gen_readme.py
@@ -19,6 +19,13 @@ def should_show_mod(mod: dict[str, Any]) -> bool:
     mod: The mod in question
     """
 
+    # Exclude plugins and libraries from being shown
+    if "flags" in mod and (
+        "plugin" in mod["flags"] or
+        "file" in mod["flags"]
+    ):
+        return False
+
     # Don't add listings for NSFW mods on the website.
     # NSFW needs to be opt-in to be shown,
     # mod managers can implement that.
@@ -54,12 +61,8 @@ MANIFEST: dict[str, Any] = json.load(sys.stdin)
 for mod_guid in MANIFEST["mods"]:
     mod: dict[str, Any] = MANIFEST["mods"][mod_guid]
 
-    # Transfer only mods to grouped_mods,
-    # leaving libs & plugins out of it
-    if ("flags" not in mod or (
-        "plugin" not in mod["flags"] and
-        "file" not in mod["flags"]
-    )) and should_show_mod(mod):
+    # Transfer only mods that should be shown to grouped_mods
+    if should_show_mod(mod):
         # Add the GUID to the mod
         mod["guid"] = mod_guid
 

--- a/gen_readme.py
+++ b/gen_readme.py
@@ -148,7 +148,18 @@ for group, mods in sorted(grouped_mods.items()):
         README += "\n\n"
 
         # Add mod description
-        README += mod["description"] + "\n"
+        README += mod["description"] + "\n\n"
+
+        # Add latest version number
+        latest_version = mod["versions"][0]
+        if "releaseUrl" in latest_version:
+            README += "Latest version: ["
+            README += str(latest_version['id'])
+            README += "]("
+            README += latest_version["releaseUrl"]
+            README += ")\n"
+        else:
+            README += f"Latest version: {str(latest_version['id'])}\n"
 
 # Output markdown to stdout
 print(README)

--- a/gen_readme.py
+++ b/gen_readme.py
@@ -133,7 +133,7 @@ for group, mods in sorted(grouped_mods.items()):
     for mod in mods:
         # Add header for the mod in question
         README += "\n<!--" + mod["guid"] + "-->\n"
-        README += "#### "
+        README += "### "
         README += f"[{mod['name']}]({mod['sourceLocation']})"
 
         # Append authors to mod header

--- a/gen_readme.py
+++ b/gen_readme.py
@@ -130,7 +130,7 @@ for group, mods in sorted(grouped_mods.items()):
         README += "\n\n"
 
         # Add mod description
-        README += mod['description'] + "\n"
+        README += mod["description"] + "\n"
 
 # Output markdown to stdout
 print(README)

--- a/gen_readme.py
+++ b/gen_readme.py
@@ -153,13 +153,19 @@ for group, mods in sorted(grouped_mods.items()):
         # Add latest version number
         latest_version = mod["versions"][0]
         if "releaseUrl" in latest_version:
-            README += "Latest version: ["
+            README += "The latest version is ["
             README += str(latest_version['id'])
             README += "]("
             README += latest_version["releaseUrl"]
-            README += ")\n"
+            README += ")"
         else:
-            README += f"Latest version: {str(latest_version['id'])}\n"
+            README += f"The latest version is {str(latest_version['id'])}"
+        if "changelog" in latest_version:
+            README += ":\n"
+            if latest_version["changelog"].strip().startswith("- "):
+                README += "\n"
+            README += latest_version["changelog"].strip()
+        README += "\n"
 
 # Output markdown to stdout
 print(README)

--- a/gen_readme.py
+++ b/gen_readme.py
@@ -22,6 +22,7 @@ def should_show_mod(mod: dict[str, Any]) -> bool:
 
     # Exclude plugins and libraries from being shown
     if "flags" in mod and (
+        "deprecated" in mod["flags"] or
         "plugin" in mod["flags"] or
         "file" in mod["flags"]
     ):


### PR DESCRIPTION
- Makes the pages markdown generation tool more flexibly so it can be easier tested locally with standard std-in/out pipes (instead of only relying on seeing the CI fail _after_ a PR has been merged due to it requiring very specific file paths to read to/from).
- Comments the code more.
- Cleans up the code that excludes some entries from being shown, hopefully avoiding edge cases that would've been possible with the current filtering where the code could generate a category title but no entries in the category.
- Preemptively adds an exclude for a category called "NSFW" from being generated to the markdown, and filters pre-release versions too.
- Parses version numbers and sorts the versions
- Adds the version numbers/links to the mods, and the changelog
- Changes the header levels back to what they should be, as ~~my linter~~ god intended