### PR TITLE
Deprecate zkxs/NoEscape

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1062,6 +1062,9 @@
                     "url": "https://github.com/zkxs"
                 }
             },
+            "flags": [
+                "deprecated"
+            ],
             "versions": {
                 "1.0.0": {
                     "releaseUrl": "https://github.com/zkxs/NoEscape/releases/tag/1.0.0.0",


### PR DESCRIPTION
Deprecate my version of NoEscape in favor of [Banane9's fork](https://github.com/Banane9/NeosNoEscape).