### PR TITLE
Proposal: Upgrade schema to be more generic

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,6 +1,6 @@
 {
-    "schemaVersion": "1.0.0",
-    "mods": {
+    "schemaVersion": "1.1.0",
+    "items": {
         "dev.zkxs.neosmodloader": {
             "name": "Neos Mod Loader",
             "description": "A mod loader for Neos VR.",
@@ -15,13 +15,13 @@
             ],
             "category": "Plugins",
             "flags": [
-                "plugin"
+                "loader"
             ],
             "versions": {
                 "1.9.1": {
                     "changelog": "Logging improvements, splash screen visuals, JSON config serialization changes",
                     "releaseUrl": "https://github.com/neos-modding-group/NeosModLoader/releases/tag/1.9.1",
-                    "neosVersionCompatibility": ">=2021.10.17.1326",
+                    "gameVersionCompatibility": ">=2021.10.17.1326",
                     "dependencies": {
                         "net.pardeike.harmony": {
                             "version": "^2.2.1"
@@ -39,7 +39,7 @@
                 "1.8.0": {
                     "changelog": "Release the new mod configuration system",
                     "releaseUrl": "https://github.com/neos-modding-group/NeosModLoader/releases/tag/1.8.0",
-                    "neosVersionCompatibility": ">=2021.10.17.1326",
+                    "gameVersionCompatibility": ">=2021.10.17.1326",
                     "dependencies": {
                         "net.pardeike.harmony": {
                             "version": "^2.2.0.0"
@@ -312,29 +312,29 @@
                 }
             }
         },
-	"net.Cyro.InterfacialAbsence": {
-	    "name": "Interfacial Absence",
-	    "description": "A mod that lets you avoid having to user LogiX Interface Proxies in Neos ",
-	    "category": "Visual Tweaks",
-	    "website": "https://github.com/RileyGuy/InterfacialAbsence",
-	    "sourceLocation": "https://github.com/RileyGuy/InterfacialAbsence",
-	    "authors": { 
-		"Cyro": { 
-		    "url": "https://github.com/RileyGuy" 
-		}
-	    },
-	    "versions": { 
-		"1.0.0": { 
-		    "releaseUrl": "https://github.com/RileyGuy/InterfacialAbsence/releases/tag/1.0.0", 
-		    "artifacts": [ 
-			{
-			    "url": "https://github.com/RileyGuy/InterfacialAbsence/releases/download/1.0.0/InterfacialAbsence.dll", 
-			    "sha256": "b5387b7afa7db76a18afa5ed314dc7500cc3ea859580c982635e09618324193a"
-			}
-		    ]
-		}
-	    }
-	},
+        "net.Cyro.InterfacialAbsence": {
+            "name": "Interfacial Absence",
+            "description": "A mod that lets you avoid having to user LogiX Interface Proxies in Neos ",
+            "category": "Visual Tweaks",
+            "website": "https://github.com/RileyGuy/InterfacialAbsence",
+            "sourceLocation": "https://github.com/RileyGuy/InterfacialAbsence",
+            "authors": {
+                "Cyro": {
+                    "url": "https://github.com/RileyGuy"
+                }
+            },
+            "versions": {
+                "1.0.0": {
+                    "releaseUrl": "https://github.com/RileyGuy/InterfacialAbsence/releases/tag/1.0.0",
+                    "artifacts": [
+                        {
+                            "url": "https://github.com/RileyGuy/InterfacialAbsence/releases/download/1.0.0/InterfacialAbsence.dll",
+                            "sha256": "b5387b7afa7db76a18afa5ed314dc7500cc3ea859580c982635e09618324193a"
+                        }
+                    ]
+                }
+            }
+        },
         "me.badhaloninja.NoLogixTraversalContext": {
             "name": "NoLogixTraversalContext",
             "description": "Hides the logix tip's node traversal context item.",
@@ -1907,7 +1907,7 @@
                 }
             }
         },
-        "net.rampa3.ExitAndDiscardHomesKeybind":{
+        "net.rampa3.ExitAndDiscardHomesKeybind": {
             "name": "ExitAndDiscardHomesKeybind",
             "description": "allows to exit without saving changes in home world using Ctrl+Alt+F4 key shortcut",
             "category": "Keybinds & Gestures",
@@ -2782,7 +2782,7 @@
                         }
                     ]
                 },
-				"1.1.1": {
+                "1.1.1": {
                     "releaseUrl": "https://github.com/Banane9/NeosBetterLogixWiresThatCanScroll/releases/tag/v1.1.1",
                     "artifacts": [
                         {
@@ -2791,7 +2791,7 @@
                         }
                     ]
                 },
-				"1.2.0": {
+                "1.2.0": {
                     "releaseUrl": "https://github.com/Banane9/NeosBetterLogixWiresThatCanScroll/releases/tag/v1.2.0",
                     "artifacts": [
                         {
@@ -2869,7 +2869,7 @@
                         }
                     ]
                 },
-				"1.2.0": {
+                "1.2.0": {
                     "releaseUrl": "https://github.com/Banane9/NeosLocalLogixRegisters/releases/tag/v1.2.0",
                     "artifacts": [
                         {
@@ -2973,7 +2973,7 @@
                         }
                     ]
                 },
-				"1.1.0": {
+                "1.1.0": {
                     "releaseUrl": "https://github.com/Banane9/NeosEditorTabbing/releases/tag/v1.1.0",
                     "artifacts": [
                         {
@@ -3483,7 +3483,7 @@
                 }
             }
         },
-        "net.Sox.EasyVoiceMessage": { 
+        "net.Sox.EasyVoiceMessage": {
             "name": "EasyVoiceMessage",
             "description": "Allows you to record voice messages without having to keep your laser on the tiny square button. (although your laser needs to stay on your dash)",
             "category": "Dash Tweaks",

--- a/review.sh
+++ b/review.sh
@@ -7,7 +7,7 @@ MOD_GUID="$1"
 MOD_VERSION="$2"
 
 BASEDIR="$(dirname "$0")"
-ARTIFACT_SELECTOR=".mods[\"$MOD_GUID\"].versions[\"$MOD_VERSION\"].artifacts[0]"
+ARTIFACT_SELECTOR=".items[\"$MOD_GUID\"].versions[\"$MOD_VERSION\"].artifacts[0]"
 FILE_URL="$(jq -r "$ARTIFACT_SELECTOR.url" "$BASEDIR/manifest.json")"
 FILE_FILENAME="$(jq -r "$ARTIFACT_SELECTOR.filename" "$BASEDIR/manifest.json")"
 FILE_SHA256="$(jq -r "$ARTIFACT_SELECTOR.sha256" "$BASEDIR/manifest.json")"


### PR DESCRIPTION
I think that it'd be nice to be able to re-use the same schema across similar modding scenes & games. The current NMG mod manifest schema though has a a few specifics that make it not properly reusable.

### Changes

One of them is that the top level key is "mods", where some loaders call the things "plugins" for example. This would change that key to just a very generic "items", since it also contains things such as the actual loaders already.

Secondly, changes the "plugin" flag to a more generic "loader" flag. The Category and tags can still remain, as I feel like those would be game specific in all cases anyways.

Thirdly, changes the `neosVersionCompatibility` to `gameVersionCompatibility`.

What spurred this change?: The influx of VRC modders & the creation of https://chilloutvr-bepinex-modders.github.io/

### For

- Makes tooling re-usable, more maintainers, Neos tooling can benefit from CVR modding tooling and vice versa
- Generally the "mods" top level key is already misleading anyways since it includes non-mods

### Against

- Will need to update existing tooling like mod updater/installer
  - Should be a really simple fix though, and can delay this untill the pre-existing tooling have been updated.
- Need to update the schema docs
  - I'd be happy to do that
- It won't be as cool of an elite Neos-only club kinda thing anymore.
  - ...Fair I guess? But it's CC0 licensed so like, don't think that's a goal