### PR TITLE
Allow manually triggering a mod list generation

### DIFF
--- a/.github/workflows/markdown-gen.yml
+++ b/.github/workflows/markdown-gen.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - master
+  workflow_dispatch:
 
 jobs:
   Generate-Markdown:
@@ -18,7 +19,7 @@ jobs:
           repository: neos-modding-group/neos-modding-group.github.io
           path: gh-pages
           ssh-key: ${{ secrets.PAGES_AUTH }}
-    
+
       - name: setup python
         uses: actions/setup-python@v3
         with:


### PR DESCRIPTION
[Documentation](https://docs.github.com/en/actions/managing-workflow-runs/manually-running-a-workflow)

This is useful if mod-list-template.md is changed over in the website repo, and we don't want to manually copy the changes over to the generated mods.md file.