### PR TITLE
Note on reducing merge conflicts

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -9,5 +9,6 @@ Make sure your submission meets the following requirements (summarized from the 
 - [ ] Do not remove old versions. Instead, use the `deprecated` [flag](https://www.neosmodloader.com/manifest-flags).
 - [ ] Indicate platform incompatibilities using the appropriate [flag](https://www.neosmodloader.com/manifest-flags) (for example `broken:linux-native`)
 - [ ] Follow the [privacy and security guidelines](https://www.neosmodloader.com/mod-guidelines#privacy-and-security)
+- [ ] In order to reduce merge conflicts avoid adding mods at the very end of the file.
 
 If you need help, check out the [submission tutorial](https://www.neosmodloader.com/submission-tutorial) or ask in the [#mod-manifest channel in our Discord](https://discord.gg/YUPK8UsBy4).


### PR DESCRIPTION
I believe the end-of-file merge conflicts are caused by having to alter the comma of the preceding mod, so I'm recommending people add their mods literally anywhere *except* the end of the file.