### PR TITLE
Clarify `deprecated` flag usage

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -6,7 +6,8 @@ Make sure your submission meets the following requirements (summarized from the 
 - [ ] Indent using four spaces. An automated check will validate this PR indents properly.
 - [ ] Your NeosMod.Version should match the version in the manifest.
 - [ ] You should not monopack libraries into your mod DLL.
-- [ ] Do not remove old versions. Instead, use the `deprecated` [flag](https://www.neosmodloader.com/manifest-flags).
+- [ ] Do not remove old versions.
+- [ ] Do not remove old mods. Instead, use the `deprecated` [flag](https://www.neosmodloader.com/manifest-flags).
 - [ ] Indicate platform incompatibilities using the appropriate [flag](https://www.neosmodloader.com/manifest-flags) (for example `broken:linux-native`)
 - [ ] Follow the [privacy and security guidelines](https://www.neosmodloader.com/mod-guidelines#privacy-and-security)
 - [ ] In order to reduce merge conflicts avoid adding mods at the very end of the file.


### PR DESCRIPTION
Clarify `deprecated` flag usage for old mods, not necessary on older versions of a mod in most cases.