### PR TITLE
Fix broken notifications workflow.

### DIFF
--- a/gen_notif.py
+++ b/gen_notif.py
@@ -141,13 +141,8 @@ def mod_to_embed(mod: dict[str, Any]) -> dict[str, Any]:
             "name": "Changelog",
             "value": mod['versions'][0]['changelog'],
         })
-    
-    
-    #escape strings
-    for str in embed:
-        str.replace("\", "\\")
-        str.replace("'", "\'")
-    
+
+
     return embed
 
 

--- a/gen_notif.py
+++ b/gen_notif.py
@@ -181,4 +181,4 @@ if len(EMBEDS) > 0:
         "avatar_url": "https://avatars.githubusercontent.com/u/101987083",
         "attachments": []
     }
-    print("::set-output name=JSON::" + json.dumps(DISCORD_JSON))
+    print("::set-output name=JSON::" + json.dumps(DISCORD_JSON).replace("\\","\\\\").replace("'", "'\\''"))

--- a/gen_notif.py
+++ b/gen_notif.py
@@ -145,8 +145,8 @@ def mod_to_embed(mod: dict[str, Any]) -> dict[str, Any]:
 
     #escape strings
     for str in embed:
-        str.replace("\\", "\\\\")
-        str.replace("'", "\\'")
+        str.replace("\", "\\")
+        str.replace("'", "\'")
 
     return embed
 

--- a/gen_notif.py
+++ b/gen_notif.py
@@ -141,13 +141,13 @@ def mod_to_embed(mod: dict[str, Any]) -> dict[str, Any]:
             "name": "Changelog",
             "value": mod['versions'][0]['changelog'],
         })
-
-
+    
+    
     #escape strings
     for str in embed:
         str.replace("\", "\\")
         str.replace("'", "\'")
-
+    
     return embed
 
 


### PR DESCRIPTION
From my testing I found that stuff like `\n` will get escaped to `\\n` which means descriptions instead of containing new lines, will contain literal `\n`.

This also reverts the completely broken and stupid code that was supposed to do this job.