### PR TITLE
Added net.earthmark.GenericTypeType to the manifest

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -6366,6 +6366,28 @@
                     ]
                 }
             }
+        },
+        "net.earthmark.GenericTypeType": {
+            "name": "GenericTypeType",
+            "description": "Adds additional type resolver steps to the generic type resolver in the component attacher, allowing nested generics using the C# syntax with some pre-defined namespace usings.",
+            "category": "Inspectors",
+            "sourceLocation": "https://github.com/Earthmark/Neos-TypeType",
+            "authors": {
+                "Earthmark": {
+                    "url": "https://github.com/Earthmark"
+                }
+            },
+            "versions": {
+                "0.0.1": {
+                    "releaseUrl": "https://github.com/Earthmark/Neos-TypeType/releases/tag/0.0.1",
+                    "artifacts": [
+                        {
+                            "url": "https://github.com/Earthmark/Neos-TypeType/releases/download/0.0.1/GenericTypeType.dll",
+                            "sha256": "1259843CEB50773A31128F54FDD55761F1DB677BC01D19D4359D1A85AC260B6D"
+                        }
+                    ]
+                }
+            }
         }
     }
 }

--- a/manifest.json
+++ b/manifest.json
@@ -4729,12 +4729,12 @@
                 }
             },
             "versions": {
-                "0.0.1": {
-                    "releaseUrl": "https://github.com/Earthmark/Neos-TypeType/releases/tag/0.0.1",
+                "0.1.1": {
+                    "releaseUrl": "https://github.com/Earthmark/Neos-TypeType/releases/tag/0.1.1",
                     "artifacts": [
                         {
-                            "url": "https://github.com/Earthmark/Neos-TypeType/releases/download/0.0.1/GenericTypeType.dll",
-                            "sha256": "1259843CEB50773A31128F54FDD55761F1DB677BC01D19D4359D1A85AC260B6D"
+                            "url": "https://github.com/Earthmark/Neos-TypeType/releases/download/0.1.1/GenericTypeType.dll",
+                            "sha256": "CC992ACAD016BBA90DE3F1883873F89CCCFE36804A4DE397B6DB6E537E8FA2CE"
                         }
                     ]
                 }

--- a/manifest.json
+++ b/manifest.json
@@ -4718,6 +4718,28 @@
                 }
             }
         },
+        "net.earthmark.GenericTypeType": {
+            "name": "GenericTypeType",
+            "description": "Adds additional type resolver steps to the generic type resolver in the component attacher, allowing nested generics using the C# syntax with some pre-defined namespace usings.",
+            "category": "Inspectors",
+            "sourceLocation": "https://github.com/Earthmark/Neos-TypeType",
+            "authors": {
+                "Earthmark": {
+                    "url": "https://github.com/Earthmark"
+                }
+            },
+            "versions": {
+                "0.0.1": {
+                    "releaseUrl": "https://github.com/Earthmark/Neos-TypeType/releases/tag/0.0.1",
+                    "artifacts": [
+                        {
+                            "url": "https://github.com/Earthmark/Neos-TypeType/releases/download/0.0.1/GenericTypeType.dll",
+                            "sha256": "1259843CEB50773A31128F54FDD55761F1DB677BC01D19D4359D1A85AC260B6D"
+                        }
+                    ]
+                }
+            }
+        },
         "me.New-Project-Final-Final-WIP.HeadlessTweaks": {
             "name": "HeadlessTweaks",
             "description": "Adds some nice to have features to headless clients",
@@ -6362,28 +6384,6 @@
                         {
                             "url": "https://github.com/TheJebForge/NegativeBlendshapes/releases/download/1.0.0/NegativeBlendshapes.dll",
                             "sha256": "c9cc37fcf532a1b806278571b43a82491cc8767e3d80dda8037afcccc79789ae"
-                        }
-                    ]
-                }
-            }
-        },
-        "net.earthmark.GenericTypeType": {
-            "name": "GenericTypeType",
-            "description": "Adds additional type resolver steps to the generic type resolver in the component attacher, allowing nested generics using the C# syntax with some pre-defined namespace usings.",
-            "category": "Inspectors",
-            "sourceLocation": "https://github.com/Earthmark/Neos-TypeType",
-            "authors": {
-                "Earthmark": {
-                    "url": "https://github.com/Earthmark"
-                }
-            },
-            "versions": {
-                "0.0.1": {
-                    "releaseUrl": "https://github.com/Earthmark/Neos-TypeType/releases/tag/0.0.1",
-                    "artifacts": [
-                        {
-                            "url": "https://github.com/Earthmark/Neos-TypeType/releases/download/0.0.1/GenericTypeType.dll",
-                            "sha256": "1259843CEB50773A31128F54FDD55761F1DB677BC01D19D4359D1A85AC260B6D"
                         }
                     ]
                 }


### PR DESCRIPTION
See https://github.com/Earthmark/Neos-TypeType

<!-- This template is provided for your convenience: feel free to delete it from your PR -->

Make sure your submission meets the following requirements (summarized from the [mod guidelines](https://www.neosmodloader.com/mod-guidelines)):

- [X] Follow the [schema](https://www.neosmodloader.com/schema). An automated check will validate this PR against the schema.
- [X] Indent using four spaces. An automated check will validate this PR indents properly.
- [X] Your NeosMod.Version should match the version in the manifest.
- [X] You should not monopack libraries into your mod DLL.
- [X] Do not remove old versions.
- [X] Do not remove old mods. Instead, use the `deprecated` [flag](https://www.neosmodloader.com/manifest-flags).
- [X] Indicate platform incompatibilities using the appropriate [flag](https://www.neosmodloader.com/manifest-flags) (for example `broken:linux-native`)
- [X] Follow the [privacy and security guidelines](https://www.neosmodloader.com/mod-guidelines#privacy-and-security)
- [X] In order to reduce merge conflicts avoid adding mods at the very end of the file.

If you need help, check out the [submission tutorial](https://www.neosmodloader.com/submission-tutorial) or ask in the [#mod-manifest channel in our Discord](https://discord.gg/YUPK8UsBy4).
