### PR TITLE
Ping `@mod release ping` on mod releases

### DIFF
--- a/gen_notif.py
+++ b/gen_notif.py
@@ -174,9 +174,9 @@ for mod_guid in NEW_MANIFEST["mods"]:
 
 if len(EMBEDS) > 0:
     DISCORD_JSON = {
-        "content": None,
+        "content": "<@&1079268851952406571>",
         "embeds": EMBEDS,
-        "allowed_mentions": { "parse": [] },
+        "allowed_mentions": { "roles": ["1079268851952406571"] },
         "username": "NMG mod verifications",
         "avatar_url": "https://avatars.githubusercontent.com/u/101987083",
         "attachments": []


### PR DESCRIPTION
It's come to my attention that it's not in the workflow of some subset of Discord users to use this radio button:
![image](https://user-images.githubusercontent.com/1807509/221394711-84fb4f69-1597-48fe-aad8-4839af832753.png)

Therefore, I'm now of the opinion that while it feels painfully redundant, announcement ping roles are a necessity for some users to be made aware that an announcement has occurred. I've already created the `@mod release ping` aka `<@&1079268851952406571>` role in the Discord, so all that's left is to update the webhook to actually ping it.

Relevant Discord API documentation:
- [Execute Webhook](https://discord.com/developers/docs/resources/webhook#execute-webhook)
- [Allowed Mentions Object](https://discord.com/developers/docs/resources/channel#allowed-mentions-object)
- [Message Formatting](https://discord.com/developers/docs/reference#message-formatting)