### PR TITLE
Allow an entire mod to be flagged as broken for a platform

### DIFF
--- a/schema.json
+++ b/schema.json
@@ -63,7 +63,7 @@
                         "type": "array",
                         "items": {
                             "type": "string",
-                            "pattern": "^(deprecated|plugin|file)$"
+                            "pattern": "^(deprecated|plugin|file|broken:(linux-native|linux-wine|windows))$"
                         }
                     },
                     "versions": {


### PR DESCRIPTION
This allows for mods that are intended to *never* be valid for a given platform, for example a mod that has Linux-only fixes.

Relevant conversation: https://github.com/neos-modding-group/neos-mod-manifest/pull/217#discussion_r1086172549