### PR TITLE
Fix Atom feeder unable to find old mod manifest

### DIFF
--- a/.github/workflows/atom-feed-update.yml
+++ b/.github/workflows/atom-feed-update.yml
@@ -13,6 +13,8 @@ jobs:
     steps:
       - name: checkout master
         uses: actions/checkout@v3
+        with:
+          fetch-depth: 2
 
       - name: checkout gh-pages
         uses: actions/checkout@v3


### PR DESCRIPTION
This is why the Github Action to regenerate the Atom feed is failing.
It wasn't checking out enough of the git history to compare the older mod manifest with the new one.