### PR TITLE
Updated GenericTypeType to 0.1.2

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -5051,6 +5051,15 @@
                             "sha256": "CC992ACAD016BBA90DE3F1883873F89CCCFE36804A4DE397B6DB6E537E8FA2CE"
                         }
                     ]
+                },
+                "0.1.2": {
+                    "releaseUrl": "https://github.com/Earthmark/Neos-TypeType/releases/tag/0.1.2",
+                    "artifacts": [
+                        {
+                            "url": "https://github.com/Earthmark/Neos-TypeType/releases/download/0.1.2/GenericTypeType.dll",
+                            "sha256": "8AA5617C4ECED9A85E886536965007A2F2CA4D2A1E1853610C14C29A47708553"
+                        }
+                    ]
                 }
             }
         },


### PR DESCRIPTION
See https://github.com/Earthmark/Neos-TypeType/releases/tag/0.1.2 for release notes.

Make sure your submission meets the following requirements (summarized from the [mod guidelines](https://www.neosmodloader.com/mod-guidelines)):

- [x] Follow the [schema](https://www.neosmodloader.com/schema). An automated check will validate this PR against the schema.
- [x] Indent using four spaces. An automated check will validate this PR indents properly.
- [x] Your NeosMod.Version should match the version in the manifest.
- [x] You should not monopack libraries into your mod DLL.
- [x] Do not remove old versions.
- [x] Do not remove old mods. Instead, use the `deprecated` [flag](https://www.neosmodloader.com/manifest-flags).
- [x] Indicate platform incompatibilities using the appropriate [flag](https://www.neosmodloader.com/manifest-flags) (for example `broken:linux-native`)
- [x] Follow the [privacy and security guidelines](https://www.neosmodloader.com/mod-guidelines#privacy-and-security)
- [x] In order to reduce merge conflicts avoid adding mods at the very end of the file.

If you need help, check out the [submission tutorial](https://www.neosmodloader.com/submission-tutorial) or ask in the [#mod-manifest channel in our Discord](https://discord.gg/YUPK8UsBy4).
