### PR TITLE
Make Atom Feeder generate IDs for feed entries

### DIFF
--- a/atom_feeder.py
+++ b/atom_feeder.py
@@ -57,6 +57,10 @@ if len(NEW_MODS) > 0:
         for mod in NEW_MODS:
             entry = atomFeed.createElement("entry")
 
+            id = atomFeed.createElement("id")
+            id.appendChild(atomFeed.createTextNode(mod["versions"][0]["releaseUrl"]))
+            entry.appendChild(id)
+
             title = atomFeed.createElement("title")
             title.appendChild(atomFeed.createTextNode("Released Version " + str(mod["versions"][0]["id"]) + " for '" + mod["name"] + "'"))
             entry.appendChild(title)


### PR DESCRIPTION
Just saw that these are mandated by the spec.