### PR TITLE
Update SessionUrlJoin to 1.1.0

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -6859,6 +6859,15 @@
                             "sha256": "6b960ea10ff6186b37ac7e84c4704754c18b0d5c7592b23f35a974749fae9b55"
                         }
                     ]
+                },
+                "1.1.0": {
+                    "releaseUrl": "https://github.com/maksim789456/SessionUrlJoin/releases/tag/1.1.0",
+                    "artifacts": [
+                        {
+                            "url": "https://github.com/maksim789456/SessionUrlJoin/releases/download/1.1.0/SessionUrlJoin.dll",
+                            "sha256": "42d50c774f2084b6a49134ce7fabccd382c3256c7272acaec64c4a184595e372"
+                        }
+                    ]
                 }
             }
         },

--- a/manifest.json
+++ b/manifest.json
@@ -6846,7 +6846,7 @@
             "website": "https://github.com/maksim789456/SessionUrlJoin",
             "sourceLocation": "https://github.com/maksim789456/SessionUrlJoin",
             "authors": {
-                "runtime": {
+                "maksim789456": {
                     "url": "https://github.com/maksim789456"
                 }
             },


### PR DESCRIPTION
Release notes: https://github.com/maksim789456/SessionUrlJoin/releases/tag/1.1.0
Fix notes from #264

- [x] Follow the [schema](https://www.neosmodloader.com/schema). An automated check will validate this PR against the schema.
- [x] Indent using four spaces. An automated check will validate this PR indents properly.
- [x] Your NeosMod.Version should match the version in the manifest.
- [x] You should not monopack libraries into your mod DLL.
- [x] Do not remove old versions.
- [x] Do not remove old mods. Instead, use the `deprecated` [flag](https://www.neosmodloader.com/manifest-flags).
- [x] Indicate platform incompatibilities using the appropriate [flag](https://www.neosmodloader.com/manifest-flags) (for example `broken:linux-native`)
- [x] Follow the [privacy and security guidelines](https://www.neosmodloader.com/mod-guidelines#privacy-and-security)
- [x] In order to reduce merge conflicts avoid adding mods at the very end of the file.
